### PR TITLE
Change Node from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ outputs:
   commits:
     description: 'commits in pr'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Node 12 has been out of support since [April 2022](https://github.com/nodejs/Release/#end-of-life-releases).