### PR TITLE
Support GitHub merge queues

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core')
 const github = require('@actions/github')
 
-const validEvent = ['pull_request']
+const validEvent = ['pull_request', 'merge_group']
 
 async function main() {
   try {


### PR DESCRIPTION
Add merge_group as a valid event. Allows the action to run against commits that are part of a merge queue.

Example failure:

github.com/submariner-io/coastguard/actions/runs/4618846627/jobs/8166807512